### PR TITLE
Fix undefined method before_filter (> Rails 5.1)

### DIFF
--- a/app/controllers/shady_controller.rb
+++ b/app/controllers/shady_controller.rb
@@ -1,5 +1,5 @@
 class ShadyController < ApplicationController
-  before_filter :authorize_global, only: [:create]
+  before_action :authorize_global, only: [:create]
 
   def create
     if pref[:shady].nil?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,4 @@
+fr:
+  label_shady_mode: Désactiver les notifications
+  notice_shady_mode: Les notifications déclanchées par vos actions, ne seront pas envoyé aux collaborateurs.
+  permission_use_shady_mode: Utiliser la désactivation des notifications

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,4 @@
 fr:
   label_shady_mode: Désactiver les notifications
-  notice_shady_mode: Les notifications déclanchées par vos actions, ne seront pas envoyé aux collaborateurs.
+  notice_shady_mode: Les notifications déclenchées par vos actions ne seront pas envoyées aux collaborateurs.
   permission_use_shady_mode: Utiliser la désactivation des notifications


### PR DESCRIPTION
Fix compatibility on Redmine 4.0.
`before_filter` has been deprecated in Rails 5.0, removed in 5.1 and replaced by `before_action` method.
I took the opportunity to add the French translation.